### PR TITLE
Footer in About Us Page

### DIFF
--- a/dist/aboutus.html
+++ b/dist/aboutus.html
@@ -108,6 +108,7 @@
   <div class="blob5"></div>
 </div>
   </div>
+  
   <!-- Footer Section -->
  
     <footer>

--- a/style/aboutus.css
+++ b/style/aboutus.css
@@ -26,6 +26,8 @@ main{
   margin: 0;
   padding: 0;
   font-size: 10px;
+  position: relative;
+  min-height: 540vh;
 
 }
 .page1{
@@ -61,6 +63,7 @@ main{
   justify-content: center;
   align-items: flex-start;
   flex-direction: column;
+  margin-top: 110px;
   gap: 20px;
 }
 .left h1{
@@ -130,6 +133,15 @@ main{
   background-repeat: no-repeat;
 }
 
+footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background-color: var(--gray); 
+  color: white;
+  padding: 20px; 
+  text-align: center;
+}
 
 @keyframes blobAnimation {
     0% {


### PR DESCRIPTION
 resolved #92 issue

Footer in about us page is not fixed to the bottom of Page.

The footer should stick to the bottom of page like this,
![after](https://github.com/youtanimstar/music-hub/assets/104455228/48bf721a-a2b2-4d3d-a2b0-e389488a8380)

The footer is not stick to bottom instead it is is between like this,
![before2](https://github.com/youtanimstar/music-hub/assets/104455228/fd78a4cc-8314-4200-b6ce-ec4e56398422)
